### PR TITLE
Provide facility to get extension point instances

### DIFF
--- a/Someta.Fody.Tests/ExtensionPointTests.cs
+++ b/Someta.Fody.Tests/ExtensionPointTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq.Expressions;
+using System.Reflection;
+using NUnit.Framework;
+using Shouldly;
+
+namespace Someta.Fody.Tests
+{
+    [TestFixture]
+    public class ExtensionPointTests
+    {
+        [Test]
+        public void FieldInitialized()
+        {
+            var o = new TestClass();
+            ObservableAsPropertyHelper<string>.ToProperty(o, x => x.StringProperty, "test");
+            var value = o.StringProperty;
+            value.ShouldBe("test");
+        }
+
+        public class TestClass
+        {
+            [ObservableAsProperty]
+            public string StringProperty { get; private set; }
+        }
+        
+        public class ObservableAsProperty : Attribute, IPropertyGetInterceptor, IStateExtensionPoint
+        {
+            public InjectedField<object> Field { get; set; }
+
+            public object GetPropertyValue(PropertyInfo propertyInfo, object instance, Func<object> getter)
+            {
+                var helper = Field.GetValue(instance);
+                var value = helper.GetType().GetProperty("Value").GetValue(helper);
+                return value;
+            }
+        }
+
+        public class ObservableAsPropertyHelper<TValue>
+        {
+            public static void ToProperty<T>(T instance, Expression<Func<T, object>> property, TValue value)
+            {
+                var propertyInfo = ((MemberExpression)property.Body).Member;
+                var extensionPoint = propertyInfo.GetExtensionPoint<ObservableAsProperty>();
+                extensionPoint.Field.SetValue(instance, new ObservableAsPropertyHelper<TValue> { Value = value });
+            }
+
+            public TValue Value { get; set; }
+        }
+    }
+}

--- a/Someta.Fody.Tests/Someta.Fody.Tests.csproj
+++ b/Someta.Fody.Tests/Someta.Fody.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="ClassLevelInterceptorTests.cs" />
     <Compile Include="DoubleStringOnSetAttribute.cs" />
     <Compile Include="EventInterceptorTests.cs" />
+    <Compile Include="ExtensionPointTests.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="InstanceInitializerTests.cs" />
     <Compile Include="MemoizeAttribute.cs" />

--- a/Someta.Fody/BaseWeaver.cs
+++ b/Someta.Fody/BaseWeaver.cs
@@ -42,6 +42,7 @@ namespace Someta.Fody
 
         public string GenerateUniqueName(IMemberDefinition member, TypeReference attributeType, string name)
         {
+            Debugger.Launch();
             var key = (member.ToString(), attributeType.FullName, name);
             if (!uniqueNamesCounter.TryGetValue(key, out var counter))
             {

--- a/Someta.Fody/BaseWeaver.cs
+++ b/Someta.Fody/BaseWeaver.cs
@@ -52,7 +52,6 @@ namespace Someta.Fody
 
             if (counter > 1)
             {
-//                Debugger.Launch();
                 name += 2;
             }
 
@@ -150,7 +149,6 @@ namespace Someta.Fody
         public FieldDefinition CacheAttributeInstance(IMemberDefinition member, FieldDefinition memberInfoField,
             ExtensionPointAttribute extensionPoint)
         {
-//            var declaringType = interceptor.Scope == InterceptorScope.Class ? interceptor.DeclaringType : type;
             var declaringType = extensionPoint.DeclaringType;
             var declaration = extensionPoint.Scope == ExtensionPointScope.Class ? declaringType : member;
             var fieldName = $"<{declaration.Name}>k__{extensionPoint.AttributeType.Name}${extensionPoint.Index}";
@@ -179,20 +177,5 @@ namespace Someta.Fody
 
             return field;
         }
-
-/*        protected void EmitAttribute(ILProcessor il, FieldReference attributeField)
-        {
-            switch (scope)
-            {
-                case InterceptorScope.Member:
-                    il.EmitGetAttribute(memberInfoField, interceptorAttribute);
-                    break;
-                case InterceptorScope.Class:
-                    il.EmitGetAttributeFromClass(method.DeclaringType, interceptorAttribute);
-                    break;
-                default:
-                    throw new InvalidOperationException();
-            }
-        }
-*/    }
+    }
 }

--- a/Someta.Fody/CecilExtensions.cs
+++ b/Someta.Fody/CecilExtensions.cs
@@ -66,6 +66,8 @@ namespace Someta.Fody
             attributeGetCustomAttributes = ModuleDefinition.ImportReference(attributeTypeDefinition.Methods.Single(x => x.Name == nameof(Attribute.GetCustomAttributes) && x.Parameters.Count == 1 && x.Parameters[0].ParameterType.CompareTo(memberInfoType)));
             var methodBaseType = ModuleDefinition.ImportReference(typeof(MethodBase));
             methodBaseGetCurrentMethod = ModuleDefinition.FindMethod(methodBaseType, nameof(MethodBase.GetCurrentMethod));
+            var extensionPointRegistry = ModuleDefinition.FindType("Someta.Helpers", "ExtensionPointRegistry", soMeta);
+            var extensionPointRegistryRegister = ModuleDefinition.FindMethod(extensionPointRegistry, "Register");
 
             var func1Type = ModuleDefinition.ImportReference(typeof(Func<>));
             var func2Type = ModuleDefinition.ImportReference(typeof(Func<,>));
@@ -145,7 +147,8 @@ namespace Someta.Fody
                 MethodInfoType = methodInfoType,
                 PropertyInfoType = propertyInfoType,
                 EventInfoType = eventInfoType,
-                ValueType = ModuleDefinition.ImportReference(typeof(ValueType))
+                ValueType = ModuleDefinition.ImportReference(typeof(ValueType)),
+                RegisterExtensionPoint = extensionPointRegistryRegister
             };
             Context = context;
         }

--- a/Someta.Fody/WeaverContext.cs
+++ b/Someta.Fody/WeaverContext.cs
@@ -35,5 +35,6 @@ namespace Someta.Fody
         public MethodReference FindMethod { get; set; }
         public MethodReference FindProperty { get; set; }
         public MethodReference OriginalMethodAttributeConstructor { get; set; }
+        public MethodReference RegisterExtensionPoint { get; set; }
     }
 }

--- a/Someta/ExtensionPoint.cs
+++ b/Someta/ExtensionPoint.cs
@@ -1,19 +1,35 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
+using Someta.Helpers;
 
 namespace Someta
 {
-    public class ExtensionPoint
+    public static class ExtensionPoint
     {
-        public IExtensionPoint GetExtensionPoint(MemberInfo member, Type extensionPointType)
+        public static T GetExtensionPoint<T>(this MemberInfo member)
+            where T : IExtensionPoint
         {
-            return null;
+            return (T)member.GetExtensionPoint(typeof(T));
         }
 
-        public IReadOnlyList<IExtensionPoint> GetExtensionPoints(MemberInfo member, Type extensionPointType)
+        public static IExtensionPoint GetExtensionPoint(this MemberInfo member, Type extensionPointType)
         {
-            return null;
+            var extensionPoints = member.GetExtensionPoints(extensionPointType).ToArray();
+            if (extensionPoints.Length > 1)
+                throw new InvalidOperationException($"More than one matching extension point of type {extensionPointType.FullName} found on {member.DeclaringType.FullName}.{member.Name}");
+            return extensionPoints.SingleOrDefault();
+        }
+
+        public static IEnumerable<IExtensionPoint> GetExtensionPoints(this MemberInfo member, Type extensionPointType)
+        {
+            return member.GetExtensionPoints().Where(x => extensionPointType.IsInstanceOfType(x));
+        }
+
+        public static IReadOnlyList<IExtensionPoint> GetExtensionPoints(this MemberInfo member)
+        {
+            return ExtensionPointRegistry.GetExtensionPoints(member);
         }
     }
 }

--- a/Someta/ExtensionPoint.cs
+++ b/Someta/ExtensionPoint.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Someta
+{
+    public class ExtensionPoint
+    {
+        public IExtensionPoint GetExtensionPoint(MemberInfo member, Type extensionPointType)
+        {
+            return null;
+        }
+
+        public IReadOnlyList<IExtensionPoint> GetExtensionPoints(MemberInfo member, Type extensionPointType)
+        {
+            return null;
+        }
+    }
+}

--- a/Someta/Helpers/ExtensionPointRegistry.cs
+++ b/Someta/Helpers/ExtensionPointRegistry.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Reflection;
+
+namespace Someta.Helpers
+{
+    public static class ExtensionPointRegistry
+    {
+        private static ConcurrentDictionary<MemberInfo, List<IExtensionPoint>> storage = new ConcurrentDictionary<MemberInfo, List<IExtensionPoint>>();
+        private static IReadOnlyList<IExtensionPoint> emptyList = new IExtensionPoint[0];
+
+        public static void Register(MemberInfo member, IExtensionPoint extensionPoint)
+        {
+            var list = storage.GetOrAdd(member, _ => new List<IExtensionPoint>());
+            lock (list)
+            {
+                list.Add(extensionPoint);
+            }
+        }
+
+        public static IReadOnlyList<IExtensionPoint> GetExtensionPoints(MemberInfo member)
+        {
+            return storage.TryGetValue(member, out var list) ? list : emptyList;
+        }
+    }
+}


### PR DESCRIPTION
This enables code outside of the extension point to get a handle to the attribute instance.  This is particularly useful when injecting state as otherwise there's no way to access that state from outside the attribute.