### PR TITLE
TypeDefinition fix for dotnet build

### DIFF
--- a/Someta.Fody/BaseWeaver.cs
+++ b/Someta.Fody/BaseWeaver.cs
@@ -73,7 +73,7 @@ namespace Someta.Fody
 
         public void ComposeTypeArgumentsIntoArray(ILProcessor il, MethodDefinition method)
         {
-            var typeType = ModuleDefinition.ImportReference(typeof(Type));
+            var typeType = ModuleDefinition.GetTypeReference(typeof(Type));
 
             // I don't fully understand this, but if this line isn't here, you'll get the error:
             // Member 'System.Type' is declared in another module and needs to be imported

--- a/Someta.Fody/CecilExtensions.cs
+++ b/Someta.Fody/CecilExtensions.cs
@@ -67,45 +67,45 @@ namespace Someta.Fody
             }
             var extensionPointRegistryRegister = ModuleDefinition.FindMethod(extensionPointRegistry, "Register");
 
-            typeType = ModuleDefinition.ImportReference(typeof(Type)).Resolve();
+            typeType = ModuleDefinition.GetTypeReference(typeof(Type)).Resolve();
             if (typeType == null)
             {
                 throw new InvalidOperationException($"System.Type was somehow not found.  Aborting.");
             }
 
-            taskType = ModuleDefinition.ImportReference(typeof(Task));
+            taskType = ModuleDefinition.GetTypeReference(typeof(Task));
             getTypeFromRuntimeHandleMethod = ModuleDefinition.ImportReference(typeType.Methods.Single(x => x.Name == "GetTypeFromHandle"));
             typeGetMethods = ModuleDefinition.ImportReference(CaptureFunc<Type, MethodInfo[]>(x => x.GetMethods(default)));
             typeGetMethod = ModuleDefinition.ImportReference(typeType.Methods.Single(x => x.Name == "GetMethod" && x.Parameters.Count == 5));
             typeGetProperty = ModuleDefinition.ImportReference(CaptureFunc<Type, PropertyInfo>(x => x.GetProperty(default, default(BindingFlags))));
             typeGetEvent = ModuleDefinition.ImportReference(CaptureFunc<Type, EventInfo>(x => x.GetEvent(default, default)));
-            taskTType = ModuleDefinition.ImportReference(typeof(Task<>));
+            taskTType = ModuleDefinition.GetTypeReference(typeof(Task<>));
             taskFromResult = ModuleDefinition.ImportReference(taskType.Resolve().Methods.Single(x => x.Name == "FromResult"));
-            attributeType = ModuleDefinition.ImportReference(typeof(Attribute));
-            var attributeTypeDefinition = ModuleDefinition.ImportReference(typeof(Attribute)).Resolve();
-            var memberInfoType = ModuleDefinition.ImportReference(typeof(MemberInfo));
+            attributeType = ModuleDefinition.GetTypeReference(typeof(Attribute));
+            var attributeTypeDefinition = ModuleDefinition.GetTypeReference(typeof(Attribute)).Resolve();
+            var memberInfoType = ModuleDefinition.GetTypeReference(typeof(MemberInfo));
             attributeGetCustomAttribute = ModuleDefinition.ImportReference(attributeTypeDefinition.Methods.Single(x => x.Name == nameof(Attribute.GetCustomAttribute) && x.Parameters.Count == 2 && x.Parameters[0].ParameterType.CompareTo(memberInfoType)));
             attributeGetCustomAttributes = ModuleDefinition.ImportReference(attributeTypeDefinition.Methods.Single(x => x.Name == nameof(Attribute.GetCustomAttributes) && x.Parameters.Count == 1 && x.Parameters[0].ParameterType.CompareTo(memberInfoType)));
-            var assemblyType = ModuleDefinition.ImportReference(typeof(Assembly));
+            var assemblyType = ModuleDefinition.GetTypeReference(typeof(Assembly));
             attributeGetCustomAttributesForAssembly = ModuleDefinition.ImportReference(attributeTypeDefinition.Methods.Single(x => x.Name == nameof(Attribute.GetCustomAttributes) && x.Parameters.Count == 1 && x.Parameters[0].ParameterType.CompareTo(assemblyType)));
-            var methodBaseType = ModuleDefinition.ImportReference(typeof(MethodBase));
+            var methodBaseType = ModuleDefinition.GetTypeReference(typeof(MethodBase));
             methodBaseGetCurrentMethod = ModuleDefinition.FindMethod(methodBaseType, nameof(MethodBase.GetCurrentMethod));
             typeGetAssembly = ModuleDefinition.ImportReference(typeType.Properties.Single(x => x.Name == nameof(Type.Assembly)).GetMethod);
 
-            var func1Type = ModuleDefinition.ImportReference(typeof(Func<>));
-            var func2Type = ModuleDefinition.ImportReference(typeof(Func<,>));
-            var action1Type = ModuleDefinition.ImportReference(typeof(Action<>));
-            var objectArrayType = ModuleDefinition.ImportReference(typeof(object[]));
-            var asyncTaskMethodBuilder = ModuleDefinition.ImportReference(typeof(AsyncTaskMethodBuilder<>));
+            var func1Type = ModuleDefinition.GetTypeReference(typeof(Func<>));
+            var func2Type = ModuleDefinition.GetTypeReference(typeof(Func<,>));
+            var action1Type = ModuleDefinition.GetTypeReference(typeof(Action<>));
+            var objectArrayType = ModuleDefinition.GetTypeReference(typeof(object[]));
+            var asyncTaskMethodBuilder = ModuleDefinition.GetTypeReference(typeof(AsyncTaskMethodBuilder<>));
             var originalMethodAtttribute = ModuleDefinition.FindType("Someta.Reflection", "OriginalMethodAttribute", soMeta);
             var originalMethodAttributeConstructor = ModuleDefinition.FindConstructor(originalMethodAtttribute);
             var methodFinder = ModuleDefinition.FindType("Someta.Reflection", "MethodFinder`1", soMeta, "T");
             var findMethod = ModuleDefinition.FindMethod(methodFinder, "FindMethod");
             var findProperty = ModuleDefinition.FindMethod(methodFinder, "FindProperty");
-            var methodInfoType = ModuleDefinition.ImportReference(typeof(MethodInfo));
-            var propertyInfoType = ModuleDefinition.ImportReference(typeof(PropertyInfo));
-            var eventInfoType = ModuleDefinition.ImportReference(typeof(EventInfo));
-            var delegateType = ModuleDefinition.ImportReference(typeof(Delegate));
+            var methodInfoType = ModuleDefinition.GetTypeReference(typeof(MethodInfo));
+            var propertyInfoType = ModuleDefinition.GetTypeReference(typeof(PropertyInfo));
+            var eventInfoType = ModuleDefinition.GetTypeReference(typeof(EventInfo));
+            var delegateType = ModuleDefinition.GetTypeReference(typeof(Delegate));
 
             var context = new WeaverContext
             {
@@ -125,44 +125,44 @@ namespace Someta.Fody
                 DelegateType = delegateType,
                 ActionTypes = new List<TypeReference>
                 {
-                    ModuleDefinition.ImportReference(typeof(Action)),
-                    ModuleDefinition.ImportReference(typeof(Action<>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Action<,,,,,,,,,,,,,,,>))
+                    ModuleDefinition.GetTypeReference(typeof(Action)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Action<,,,,,,,,,,,,,,,>))
                 },
                 FuncTypes = new List<TypeReference>
                 {
-                    ModuleDefinition.ImportReference(typeof(Func<>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,,,,,>)),
-                    ModuleDefinition.ImportReference(typeof(Func<,,,,,,,,,,,,,,,,>))
+                    ModuleDefinition.GetTypeReference(typeof(Func<>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,,,,,>)),
+                    ModuleDefinition.GetTypeReference(typeof(Func<,,,,,,,,,,,,,,,,>))
                 },
                 OriginalMethodAttributeConstructor = originalMethodAttributeConstructor,
                 FindMethod = findMethod,
@@ -170,7 +170,7 @@ namespace Someta.Fody
                 MethodInfoType = methodInfoType,
                 PropertyInfoType = propertyInfoType,
                 EventInfoType = eventInfoType,
-                ValueType = ModuleDefinition.ImportReference(typeof(ValueType)),
+                ValueType = ModuleDefinition.GetTypeReference(typeof(ValueType)),
                 RegisterExtensionPoint = extensionPointRegistryRegister
             };
             Context = context;

--- a/Someta.Fody/ReferenceFinder.cs
+++ b/Someta.Fody/ReferenceFinder.cs
@@ -1,0 +1,30 @@
+﻿using Mono.Cecil;
+using System;
+using System.Linq;
+
+namespace Someta.Fody
+{
+    internal static class ReferenceFinder
+    {
+        internal static TypeReference GetTypeReference(this ModuleDefinition moduleDefinition, Type type, string netCoreAssemblyHint = null)
+        {
+            var importedType = moduleDefinition.ImportReference(type);
+            // On .NET Core, we need to rewrite mscorlib types to use the
+            // dot net assemblies from the weaved assembly and not the ones
+            // used by the weaver itself.
+            if (importedType is TypeSpecification)
+                return importedType;
+
+            var scope = importedType.Scope;
+            if (scope.Name != moduleDefinition.TypeSystem.CoreLibrary.Name)
+                scope = moduleDefinition.TypeSystem.CoreLibrary;
+
+            if (scope.Name == "System.Runtime" && netCoreAssemblyHint != null)
+                scope = new AssemblyNameReference(netCoreAssemblyHint,
+                    moduleDefinition.AssemblyReferences.First(mr => mr.Name == "System.Runtime").Version);
+
+            importedType.Scope = scope;
+            return importedType;
+        }
+    }
+}


### PR DESCRIPTION
Build from Visual Studio works fine. dotnet build from something like Azure build pipeline does not and gives an exception "System.Type was somehow not found.  Aborting." These modification address that problem and the artifacts are built correctly. Can be tested using powershell "dotnet build".